### PR TITLE
dm-review-branch: open meld and kdiff3 after the textual review

### DIFF
--- a/usr/bin/dm-review-branch
+++ b/usr/bin/dm-review-branch
@@ -19,4 +19,8 @@ git log "...${1}"
 
 git-diff-review "...${1}"
 
+git-meld "...${1}"
+
+git-kdiff3 "...${1}"
+
 true "$0: OK."


### PR DESCRIPTION
`dm-review-branch` currently runs only `git-diff-review` (the terminal-safe textual pass). Restore the GUI diff review it used to provide by also invoking `git-meld` and `git-kdiff3` after it, so a branch review opens all three tools.

All three are the sibling safe drivers over the shared hardened `git-review-driver.sh` core, so mode / symlink / gitlink-spoof / Trojan-Source-Unicode / binary changes stay surfaced in every one.

bash -n + shellcheck -x clean; pre-push static gate green.
